### PR TITLE
Use the getter for ed25519 pubkey

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,9 +11,9 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache cargo bin
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-audit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   tendermint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -32,7 +32,7 @@ jobs:
   build-light-client-wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -33,7 +33,7 @@ jobs:
   clippy_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -47,7 +47,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-03-25
+          toolchain: nightly
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
   tendermint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -36,7 +36,7 @@ jobs:
   tendermint-rpc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -48,7 +48,7 @@ jobs:
   tendermint-proto:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -60,7 +60,7 @@ jobs:
   tendermint-light-client:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -73,7 +73,7 @@ jobs:
   tendermint-light-client-js:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: wasm-pack test --headless --chrome ./light-client-js/
@@ -81,7 +81,7 @@ jobs:
   tendermint-light-node:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -93,7 +93,7 @@ jobs:
   tendermint-testgen:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -113,7 +113,7 @@ jobs:
           - 26657:26657
           - 26660:26660
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -128,7 +128,7 @@ jobs:
   nightly-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ light-client-js/pkg/
 light-client-js/examples/verifier-web/node_modules/
 light-client-js/examples/verifier-web/dist/
 light-client-js/examples/verifier-web/package-lock.json
+
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ members = [
 exclude = [
     "proto-compiler"
 ]
+
+[patch.crates-io]
+ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,3 @@ members = [
     "testgen",
     "pbt-gen"
 ]
-
-exclude = [
-    "proto-compiler"
-]
-
-[patch.crates-io]
-ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek" }

--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -28,7 +28,7 @@ binary = [ "structopt", "tracing-subscriber" ]
 [dependencies]
 bytes = "1.0"
 eyre = "0.6"
-prost = "0.7"
+prost = "0.11"
 tendermint-proto = { version = "0.19.0", path = "../proto" }
 thiserror = "1.0"
 tracing = "0.1"

--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "tendermint-abci"
 version     = "0.19.0"
 authors     = ["Thane Thomson <thane@informal.systems>"]
-edition     = "2018"
+edition     = "2021"
 license     = "Apache-2.0"
 readme      = "README.md"
 keywords    = ["abci", "blockchain", "bft", "consensus", "tendermint"]

--- a/abci/src/lib.rs
+++ b/abci/src/lib.rs
@@ -9,6 +9,9 @@
 //! have them interact. In practice, the client interaction will be performed
 //! by a full Tendermint node.
 //!
+#[cfg_attr(
+    all(feature = "client", feature = "kvstore-app"),
+    doc = r##"
 //! ```rust
 //! use tendermint_abci::{KeyValueStoreApp, ServerBuilder, ClientBuilder};
 //! use tendermint_proto::abci::{RequestEcho, RequestDeliverTx, RequestQuery};
@@ -52,7 +55,8 @@
 //!     .unwrap();
 //! assert_eq!(res.value, "test-value".as_bytes().to_owned());
 //! ```
-
+""##
+)]
 mod application;
 #[cfg(feature = "client")]
 mod client;

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       = "tendermint-p2p"
 version    = "0.19.0"
-edition    = "2018"
+edition    = "2021"
 license    = "Apache-2.0"
 repository = "https://github.com/informalsystems/tendermint-rs"
 readme     = "README.md"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -16,14 +16,14 @@ description = """
     """
 
 [dependencies]
-chacha20poly1305 = "0.7"
-ed25519-dalek = "1"
+chacha20poly1305 = "0.10.1"
+ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek", tag = "v1.0.1-f", features = ["serde"] }
 eyre = "0.6"
-hkdf = "0.10.0"
-merlin = "2"
-prost = "0.7"
+hkdf = "0.12.3"
+merlin = "3"
+prost = "0.11"
 rand_core = { version = "0.5", features = ["std"] }
-sha2 = "0.9"
+sha2 = "0.10"
 subtle = "2"
 subtle-encoding = { version = "0.5" }
 thiserror = "1"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -22,12 +22,12 @@ eyre = "0.6"
 hkdf = "0.12.3"
 merlin = "3"
 prost = "0.11"
-rand_core = { version = "0.5", features = ["std"] }
+rand_core = { version = "0.6", features = ["std"] }
 sha2 = "0.10"
 subtle = "2"
 subtle-encoding = { version = "0.5" }
 thiserror = "1"
-x25519-dalek = "1.1"
+x25519-dalek = { git = "https://github.com/FindoraNetwork/x25519-dalek", tag = "v1.2.1-f" }
 zeroize = "1"
 
 # path dependencies

--- a/p2p/src/secret_connection.rs
+++ b/p2p/src/secret_connection.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 use chacha20poly1305::{
-    aead::{generic_array::GenericArray, AeadInPlace, NewAead},
-    ChaCha20Poly1305,
+    aead::{generic_array::GenericArray, AeadInPlace},
+    ChaCha20Poly1305, KeyInit,
 };
 use ed25519_dalek::{self as ed25519, Signer, Verifier};
 use eyre::{eyre, Result, WrapErr};

--- a/pbt-gen/Cargo.toml
+++ b/pbt-gen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tendermint-pbt-gen"
 version = "0.19.0"
 authors = ["Shon Feder <shon@informal.systems>"]
-edition = "2018"
+edition = "2021"
 description = """
             An internal crate providing proptest generators used across our
             crates and not depending on any code internal to those crates.

--- a/pbt-gen/Cargo.toml
+++ b/pbt-gen/Cargo.toml
@@ -16,4 +16,4 @@ time = ["chrono"]
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"], optional = true}
-proptest = "0.10.1"
+proptest = "1.0.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tendermint-proto"
 version = "0.19.0"
 authors = ["Greg Szabo <greg@informal.systems>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/informalsystems/tendermint-rs/tree/master/proto"
 readme     = "README.md"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -17,8 +17,8 @@ description = """
 all-features = true
 
 [dependencies]
-prost = "0.7"
-prost-types = "0.7"
+prost = "0.11"
+prost-types = "0.11"
 bytes = "1.0"
 anomaly = { git = "https://github.com/FindoraNetwork/anomaly.git", branch = "main" }
 thiserror = "1.0"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       = "tendermint-rpc"
 version    = "0.19.0"
-edition    = "2018"
+edition    = "2021"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/informalsystems/tendermint-rs"

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -61,10 +61,10 @@ url = { version = "2.2" }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
 k256 = { version = "0.11.6", optional = true, features = ["ecdsa"] }
-ripemd160 = { version = "0.9", optional = true }
+ripemd = { version = "0.1", optional = true }
 
 [features]
-secp256k1 = ["k256", "ripemd160"]
+secp256k1 = ["k256", "ripemd"]
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -38,19 +38,19 @@ async-trait = "0.1"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 ed25519 = "1"
-ed25519-dalek = { version = "1", features = ["serde"] }
+ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek", tag = "v1.0.1-f", features = ["serde"] }
 # TODO(thane): Remove once https://github.com/myrrlyn/funty/issues/3 is fixed
 funty = "=1.1.0"
 futures = "0.3"
 num-traits = "0.2"
 once_cell = "1.3"
-prost = "0.7"
-prost-types = "0.7"
+prost = "0.11"
+prost-types = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_bytes = "0.11"
 serde_repr = "0.1"
-sha2 = { version = "0.9", default-features = false }
+sha2 = { version = "0.10", default-features = false }
 signature = "1.2"
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
@@ -60,12 +60,12 @@ toml = { version = "0.5" }
 url = { version = "2.2" }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
-k256 = { version = "0.7", optional = true, features = ["ecdsa"] }
+k256 = { version = "0.11.6", optional = true, features = ["ecdsa"] }
 ripemd160 = { version = "0.9", optional = true }
 
 [features]
 secp256k1 = ["k256", "ripemd160"]
 
 [dev-dependencies]
-proptest = "0.10.1"
+proptest = "1.0.0"
 tendermint-pbt-gen = { path = "../pbt-gen" }

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/informalsystems/tendermint-rs/tree/master/tende
 readme     = "../README.md"
 categories = ["cryptography", "cryptography::cryptocurrencies", "database"]
 keywords   = ["blockchain", "bft", "consensus", "cosmos", "tendermint"]
-edition    = "2018"
+edition    = "2021"
 
 description = """
     Tendermint is a high-performance blockchain consensus engine that powers

--- a/tendermint/src/account.rs
+++ b/tendermint/src/account.rs
@@ -18,7 +18,7 @@ use subtle_encoding::hex;
 #[cfg(feature = "secp256k1")]
 use crate::public_key::Secp256k1;
 #[cfg(feature = "secp256k1")]
-use ripemd160::Ripemd160;
+use ripemd::Ripemd160;
 use std::convert::TryFrom;
 use tendermint_proto::Protobuf;
 

--- a/tendermint/src/config/node_key.rs
+++ b/tendermint/src/config/node_key.rs
@@ -43,7 +43,7 @@ impl NodeKey {
     /// Get the public key for this keypair
     pub fn public_key(&self) -> PublicKey {
         match &self.priv_key {
-            PrivateKey::Ed25519(keypair) => keypair.public.into(),
+            PrivateKey::Ed25519(keypair) => keypair.public_key().into(),
         }
     }
 

--- a/tendermint/src/private_key.rs
+++ b/tendermint/src/private_key.rs
@@ -25,7 +25,7 @@ impl PrivateKey {
     /// Get the public key associated with this private key
     pub fn public_key(&self) -> PublicKey {
         match self {
-            PrivateKey::Ed25519(private_key) => private_key.public.into(),
+            PrivateKey::Ed25519(private_key) => private_key.public_key().into(),
         }
     }
 

--- a/tendermint/src/proposal.rs
+++ b/tendermint/src/proposal.rs
@@ -119,7 +119,7 @@ mod tests {
     use crate::chain::Id as ChainId;
     use crate::hash::{Algorithm, Hash};
     use crate::proposal::SignProposalRequest;
-    use crate::signature::{Ed25519Signature, ED25519_SIGNATURE_SIZE};
+    use crate::signature::Ed25519Signature;
     use crate::{proposal::Type, Proposal, Signature};
     use chrono::{DateTime, Utc};
     use std::str::FromStr;
@@ -150,7 +150,9 @@ mod tests {
                 .unwrap(),
             }),
             timestamp: Some(dt.into()),
-            signature: Signature::Ed25519(Ed25519Signature::new([0; ED25519_SIGNATURE_SIZE])),
+            signature: Signature::Ed25519(
+                Ed25519Signature::from_bytes(&[0; Ed25519Signature::BYTE_SIZE]).unwrap(),
+            ),
         };
 
         let mut got = vec![];
@@ -232,7 +234,9 @@ mod tests {
                 .unwrap(),
             }),
             timestamp: Some(dt.into()),
-            signature: Signature::Ed25519(Ed25519Signature::new([0; ED25519_SIGNATURE_SIZE])),
+            signature: Signature::Ed25519(
+                Ed25519Signature::from_bytes(&[0; Ed25519Signature::BYTE_SIZE]).unwrap(),
+            ),
         };
 
         let mut got = vec![];
@@ -316,7 +320,9 @@ mod tests {
                 )
                 .unwrap(),
             }),
-            signature: Signature::Ed25519(Ed25519Signature::new([0; ED25519_SIGNATURE_SIZE])),
+            signature: Signature::Ed25519(
+                Ed25519Signature::from_bytes(&[0; Ed25519Signature::BYTE_SIZE]).unwrap(),
+            ),
         };
         let want = SignProposalRequest {
             proposal,

--- a/tendermint/src/signature.rs
+++ b/tendermint/src/signature.rs
@@ -1,6 +1,6 @@
 //! Cryptographic (a.k.a. digital) signatures
 
-pub use ed25519::{Signature as Ed25519Signature, SIGNATURE_LENGTH as ED25519_SIGNATURE_SIZE};
+pub use ed25519::Signature as Ed25519Signature;
 pub use signature::{Signer, Verifier};
 
 #[cfg(feature = "secp256k1")]
@@ -30,12 +30,12 @@ impl TryFrom<Vec<u8>> for Signature {
         if value.is_empty() {
             return Ok(Self::default());
         }
-        if value.len() != ED25519_SIGNATURE_SIZE {
+        if value.len() != Ed25519Signature::BYTE_SIZE {
             return Err(Kind::InvalidSignatureIdLength.into());
         }
-        let mut slice: [u8; ED25519_SIGNATURE_SIZE] = [0; ED25519_SIGNATURE_SIZE];
+        let mut slice: [u8; Ed25519Signature::BYTE_SIZE] = [0; Ed25519Signature::BYTE_SIZE];
         slice.copy_from_slice(&value[..]);
-        Ok(Signature::Ed25519(Ed25519Signature::new(slice)))
+        Ok(Signature::Ed25519(Ed25519Signature::from_bytes(&slice)?))
     }
 }
 

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -5,7 +5,7 @@ use crate::error::{Error, Kind};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use std::convert::{Infallible, TryFrom};
+use std::convert::TryFrom;
 use std::fmt;
 use std::ops::{Add, Sub};
 use std::str::FromStr;
@@ -23,7 +23,7 @@ pub struct Time(DateTime<Utc>);
 impl Protobuf<Timestamp> for Time {}
 
 impl TryFrom<Timestamp> for Time {
-    type Error = Infallible;
+    type Error = <SystemTime as TryFrom<prost_types::Timestamp>>::Error;
 
     fn try_from(value: Timestamp) -> Result<Self, Self::Error> {
         // prost_types::Timestamp has a SystemTime converter but
@@ -33,7 +33,7 @@ impl TryFrom<Timestamp> for Time {
             nanos: value.nanos,
         };
 
-        Ok(SystemTime::from(prost_value).into())
+        Ok(SystemTime::try_from(prost_value)?.into())
     }
 }
 

--- a/tendermint/src/vote.rs
+++ b/tendermint/src/vote.rs
@@ -16,7 +16,6 @@ use crate::{account, block, Signature, Time};
 use crate::{Error, Kind::*};
 use bytes::BufMut;
 use ed25519::Signature as ed25519Signature;
-use ed25519::SIGNATURE_LENGTH as ed25519SignatureLength;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -166,7 +165,9 @@ impl Default for Vote {
             timestamp: Some(Time::unix_epoch()),
             validator_address: account::Id::new([0; account::LENGTH]),
             validator_index: ValidatorIndex::try_from(0_i32).unwrap(),
-            signature: Ed25519(ed25519Signature::new([0; ed25519SignatureLength])),
+            signature: Ed25519(
+                ed25519Signature::from_bytes(&[0; ed25519Signature::BYTE_SIZE]).unwrap(),
+            ),
         }
     }
 }

--- a/tendermint/src/vote/sign_vote.rs
+++ b/tendermint/src/vote/sign_vote.rs
@@ -98,7 +98,7 @@ mod tests {
     use crate::block::Round;
     use crate::chain::Id as ChainId;
     use crate::hash::Algorithm;
-    use crate::signature::{Signature, ED25519_SIGNATURE_SIZE};
+    use crate::signature::Signature;
     use crate::vote::{CanonicalVote, ValidatorIndex};
     use crate::vote::{SignVoteRequest, Type};
     use crate::Hash;
@@ -427,7 +427,7 @@ mod tests {
                 )
                 .unwrap(),
             }),
-            signature: Signature::try_from(vec![1; ED25519_SIGNATURE_SIZE]).unwrap(),
+            signature: Signature::try_from(vec![1; ed25519::Signature::BYTE_SIZE]).unwrap(),
         };
         let want = SignVoteRequest {
             vote,

--- a/tendermint/tests/config.rs
+++ b/tendermint/tests/config.rs
@@ -26,7 +26,7 @@ mod files {
         );
         assert_eq!(config.moniker.as_ref(), "technodrome");
         assert!(config.fast_sync);
-        assert_eq!(config.db_backend, DbBackend::LevelDb);
+        assert_eq!(config.db_backend, DbBackend::GoLevelDb);
         assert_eq!(config.db_dir, PathBuf::from("data"));
         assert_eq!(config.log_level.get("main"), Some("info"));
         assert_eq!(config.log_level.get("state"), Some("info"));

--- a/tendermint/tests/support/config/config.toml
+++ b/tendermint/tests/support/config/config.toml
@@ -15,8 +15,8 @@ moniker = "technodrome"
 # and verifying their commits
 fast_sync = true
 
-# Database backend: leveldb | memdb | cleveldb
-db_backend = "leveldb"
+# Database backend: goleveldb | memdb | cleveldb
+db_backend = "goleveldb"
 
 # Database directory
 db_dir = "data"

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tendermint-testgen"
 version = "0.19.0"
 authors = ["Andrey Kuprianov <andrey@informal.systems>", "Shivani Joshi <shivani@informal.systems>"]
-edition = "2018"
+edition = "2021"
 readme  = "README.md"
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -17,7 +17,7 @@ description = """
 tendermint = { version = "0.19.0", path = "../tendermint" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-ed25519-dalek = "1"
+ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek", tag = "v1.0.1-f", features = ["serde"] }
 gumdrop = "0.8.0"
 simple-error = "0.2.1"
 tempfile = "3.1.0"

--- a/testgen/src/validator.rs
+++ b/testgen/src/validator.rs
@@ -51,8 +51,7 @@ impl Validator {
             Ed25519SecretKey::from_bytes(&bytes).ok(),
             "failed to construct a seed from validator identifier"
         );
-        let public = public_key::Ed25519::from(&secret);
-        Ok(private_key::Ed25519 { secret, public })
+        Ok(private_key::Ed25519::from(secret))
     }
 
     /// Get public key for this validator companion.

--- a/testgen/src/vote.rs
+++ b/testgen/src/vote.rs
@@ -3,9 +3,10 @@ use gumdrop::Options;
 use serde::{Deserialize, Serialize};
 use simple_error::*;
 use std::convert::TryFrom;
+use tendermint::signature::Ed25519Signature;
 use tendermint::{
     block::{self, parts::Header as PartSetHeader},
-    signature::{self, Signature, Signer, ED25519_SIGNATURE_SIZE},
+    signature::{self, Signature, Signer},
     vote,
     vote::ValidatorIndex,
 };
@@ -131,7 +132,7 @@ impl Generator<vote::Vote> for Vote {
             validator_address: block_validator.address,
             validator_index: ValidatorIndex::try_from(validator_index as u32).unwrap(),
             signature: Signature::Ed25519(try_with!(
-                signature::Ed25519Signature::try_from(&[0_u8; ED25519_SIGNATURE_SIZE][..]),
+                signature::Ed25519Signature::try_from(&[0_u8; Ed25519Signature::BYTE_SIZE][..]),
                 "failed to construct empty ed25519 signature"
             )),
         };

--- a/tools/proto-compiler/Cargo.toml
+++ b/tools/proto-compiler/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 walkdir         = { version = "2.3" }
-prost-build     = { version = "0.7" }
-git2            = { version = "0.13" }
+prost-build     = { version = "0.11" }
+git2            = { version = "0.15" }
 tempdir         = { version = "0.3" }
 subtle-encoding = { version = "0.5" }


### PR DESCRIPTION
The current PR obtains the public key by directly accessing a field. However, the more standard practice is to use the getter. This PR does so.

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant

N/A:
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
